### PR TITLE
feat: add plugin-core package

### DIFF
--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -4,6 +4,7 @@
   "description": "TODO: write a description",
   "license": "{{cookiecutter.license}}",
   "dependencies": {
+    "@cortexapps/plugin-core": "^0.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/{{cookiecutter.project_name}}/src/api/Cortex.ts
+++ b/{{cookiecutter.project_name}}/src/api/Cortex.ts
@@ -1,0 +1,7 @@
+import { CortexApi, type CortexContextResponse } from "@cortexapps/plugin-core";
+
+export const getCortexContext = async (): Promise<CortexContextResponse> => {
+  const context = await CortexApi.getContext();
+
+  return context;
+};

--- a/{{cookiecutter.project_name}}/src/components/App.tsx
+++ b/{{cookiecutter.project_name}}/src/components/App.tsx
@@ -2,8 +2,19 @@ import type React from "react";
 import logo from "../assets/logo.svg";
 import "../baseStyles.css";
 import ErrorBoundary from "./ErrorBoundary";
+import { useEffect } from "react";
+import { getCortexContext } from "../api/Cortex";
 
 const App: React.FC = () => {
+  useEffect(() => {
+    const fetchContext = async (): Promise<void> => {
+      const context = await getCortexContext();
+      console.log(`Cortex context:`, context);
+    };
+
+    void fetchContext();
+  });
+
   return (
     <ErrorBoundary>
       <div>


### PR DESCRIPTION
## Background
We did not auto-include `@cortexapps/plugin-core` until now because it wasn't published to a public registry. However, now it is published publicly to npmjs.org.

## This PR
* Adds `@cortexapps/plugin-core` as a dependency to the created repo
* Adds a simple fetch/log on app load as a demo for using context