### PR TITLE
chore: add readme with basic directions

### DIFF
--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -1,6 +1,6 @@
 # {{ cookiecutter.project_name }}
 
-{{ cookiecutter.project_name }} is a [Cortex](https://www.cortex.io/) plugin. To see how to run the plugin inside of Cortex, see [the docs](https://docs.cortex.io/docs/plugins).
+{{ cookiecutter.project_name }} is a [Cortex](https://www.cortex.io/) plugin. To see how to run the plugin inside of Cortex, see [our docs](https://docs.cortex.io/docs/plugins).
 
 ### Prerequisites
 

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -1,0 +1,21 @@
+# {{ cookiecutter.project_name }}
+
+{{ cookiecutter.project_name }} is a [Cortex](https://www.cortex.io/) plugin. To see how to run the plugin inside of Cortex, see [the docs](https://docs.cortex.io/docs/plugins).
+
+### Prerequisites
+
+Developing and building this plugin requires either [yarn](https://classic.yarnpkg.com/lang/en/docs/install/) or [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+## Getting started
+
+1. Run `yarn` or `npm install` to download all dependencies
+2. Run `yarn build` or `npm run build` to compile the plugin code into `./dist/ui.html`
+3. Upload `ui.html` into Cortex on a create or edit plugin page
+4. Add or update the code and repeat steps 2-3 as necessary
+
+### Notable scripts
+
+The following commands come pre-configured in this repository. You can see all available commands in the `scripts` section of [package.json](./package.json). They can be run with npm via `npm run {script_name}` or with yarn via `yarn {script_name}`, depending on your package manager preference. For instance, the `build` command can be run with `npm run build` or `yarn build`.
+* `build` - compiles the plugin. The compiled code root is `./src/index.tsx` (or as defined by [webpack.config.js](webpack.config.js)) and the output is generated into `dist/ui.html`.
+* `test` - runs all tests defined in the repository using [jest](https://jestjs.io/)
+* `lint` - runs lint and format checking on the repository using [prettier](https://prettier.io/) and [eslint](https://eslint.org/)


### PR DESCRIPTION
### Background
@themsquared and @cremerfc noticed that the generated cookieecutter project doesn't have a readme and is an easy place for devs to get stuck.

### This PR
Adds a simple README with some basic info to minimize the chance of users getting stuck after creating the plugin repo.