### PR TITLE
feat: update plugin core usage

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,5 @@
 {
   "project_name": "my-cortex-plugin",
-  "user": "anonymous",
-  "author": "anonymous",
   "license": "MIT",
-  "version_control_domain": "github.com",
-  "repository": "https://{{cookiecutter.version_control_domain}}/{{cookiecutter.user}}/{{cookiecutter.project_name}}",
   "version": "0.1.0"
 }

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -16,6 +16,13 @@ Developing and building this plugin requires either [yarn](https://classic.yarnp
 ### Notable scripts
 
 The following commands come pre-configured in this repository. You can see all available commands in the `scripts` section of [package.json](./package.json). They can be run with npm via `npm run {script_name}` or with yarn via `yarn {script_name}`, depending on your package manager preference. For instance, the `build` command can be run with `npm run build` or `yarn build`.
-* `build` - compiles the plugin. The compiled code root is `./src/index.tsx` (or as defined by [webpack.config.js](webpack.config.js)) and the output is generated into `dist/ui.html`.
-* `test` - runs all tests defined in the repository using [jest](https://jestjs.io/)
-* `lint` - runs lint and format checking on the repository using [prettier](https://prettier.io/) and [eslint](https://eslint.org/)
+
+- `build` - compiles the plugin. The compiled code root is `./src/index.tsx` (or as defined by [webpack.config.js](webpack.config.js)) and the output is generated into `dist/ui.html`.
+- `test` - runs all tests defined in the repository using [jest](https://jestjs.io/)
+- `lint` - runs lint and format checking on the repository using [prettier](https://prettier.io/) and [eslint](https://eslint.org/)
+- `lintfix` - runs eslint in fix mode to fix any linting errors that can be fixed automatically
+- `formatfix` - runs Prettier in fix mode to fix any formatting errors that can be fixed automatically
+
+### Available React components
+
+See available UI components via our [Storybook](https://cortexapps.github.io/plugin-core/).

--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -1,10 +1,9 @@
 {
   "name": "{{cookiecutter.project_name}}",
   "version": "{{cookiecutter.version}}",
-  "description": "TODO: write a description",
   "license": "{{cookiecutter.license}}",
   "dependencies": {
-    "@cortexapps/plugin-core": "^0.3.1",
+    "@cortexapps/plugin-core": "^1.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/{{cookiecutter.project_name}}/src/components/App.tsx
+++ b/{{cookiecutter.project_name}}/src/components/App.tsx
@@ -1,26 +1,48 @@
 import type React from "react";
-import logo from "../assets/logo.svg";
+import {
+  Box,
+  Button,
+  Logo,
+  Stack,
+  ThemeProvider,
+  Title,
+} from "@cortexapps/plugin-core/components";
 import "../baseStyles.css";
 import ErrorBoundary from "./ErrorBoundary";
-import { useEffect } from "react";
+import { useCallback, useState } from "react";
 import { getCortexContext } from "../api/Cortex";
 
 const App: React.FC = () => {
-  useEffect(() => {
-    const fetchContext = async (): Promise<void> => {
-      const context = await getCortexContext();
-      console.log(`Cortex context:`, context);
-    };
+  const [cortexContext, setCortexContext] = useState<any>(null);
 
-    void fetchContext();
-  });
+  const fetchContext = useCallback(async () => {
+    const context = await getCortexContext();
+    setCortexContext(context);
+  }, []);
 
   return (
     <ErrorBoundary>
-      <div>
-        <img src={logo} />
-        <h2>My Awesome Cortex Plugin</h2>
-      </div>
+      <ThemeProvider>
+        <Stack>
+          <Logo />
+          <Title level={1}>My Awesome Cortex Plugin</Title>
+          <Box>
+            <Button
+              onClick={() => {
+                void fetchContext();
+              }}
+            >
+              View context
+            </Button>
+          </Box>
+          {Boolean(cortexContext) && (
+            <>
+              <Title level={2}>Plugin context</Title>
+              <pre>{JSON.stringify(cortexContext, null, 2)}</pre>
+            </>
+          )}
+        </Stack>
+      </ThemeProvider>
     </ErrorBoundary>
   );
 };


### PR DESCRIPTION
* Updates the template to use the newest version of `@cortexapps/plugin-core`, which includes the component library
* Updates instructions
  * Adds a link to the plugin components storybook
* Updates the base template to use `<ThemeProvider>` and have a slightly more useful/dynamic demo

https://github.com/cortexapps/cookiecutter-cortex-plugin/assets/3069614/a03b41bf-3466-479d-8001-577029a20dee

