### PR TITLE
feat: set up webpack dev server

### DIFF
--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -40,11 +40,13 @@
     "typescript": "^4.9.5",
     "url-loader": "^4.1.1",
     "webpack": "^5.76.1",
-    "webpack-cli": "^5.0.1"
+    "webpack-cli": "^5.0.1",
+    "webpack-dev-server": "^4.15.0"
   },
   "scripts": {
     "build": "webpack --mode=production",
     "clean": "rm -r ./dist",
+    "dev": "webpack serve --mode=development",
     "formatfix": "yarn prettier . --write",
     "formatcheck": "yarn prettier . --check",
     "lint": "run-p formatcheck lintcheck",

--- a/{{cookiecutter.project_name}}/webpack.config.js
+++ b/{{cookiecutter.project_name}}/webpack.config.js
@@ -44,6 +44,7 @@ module.exports = (env, argv) => ({
   output: {
     filename: "[name].js",
     path: path.resolve(__dirname, "dist"), // Compile into a folder named "dist"
+    publicPath: '',
   },
 
   // Tells Webpack to generate "ui.html" and to inline "ui.ts" into it
@@ -56,4 +57,12 @@ module.exports = (env, argv) => ({
     }),
     new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/ui/]),
   ],
+
+  devServer: {
+    compress: true,
+    port: 9000,
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
+  },
 });


### PR DESCRIPTION
### Background

To improve DX, we want to enable some sort of hot loading of the plugin so devs don't have to keep re-running `yarn build` and doing a file upload to work on their plugin.

### This PR

Sets up webpack dev server ([docs](https://webpack.js.org/configuration/dev-server/)) to serve static files (in `dist/`) with hot reloading from http://localhost:9000. This will enable us to put a toggle in the Cortex app that points the iframe to this URL (instead of srcdoc) for easier development.