### PR TITLE
fix: pull in jest config fixes

### DIFF
--- a/{{cookiecutter.project_name}}/babel.config.js
+++ b/{{cookiecutter.project_name}}/babel.config.js
@@ -3,6 +3,6 @@ module.exports = {
   presets: [
     ["@babel/preset-env", { targets: { node: "current" } }],
     "@babel/preset-typescript",
-    "@babel/preset-react",
+    ["@babel/preset-react", { runtime: "automatic" }]
   ],
 };

--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -3,7 +3,7 @@
   "version": "{{cookiecutter.version}}",
   "license": "{{cookiecutter.license}}",
   "dependencies": {
-    "@cortexapps/plugin-core": "^1.1.0",
+    "@cortexapps/plugin-core": "^1.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Our jest setup for plugins was broken and requires 2 changes to fix.

1. `@cortexapps/plugin-core` should generate cjs output instead of esm (this is a temporary fix)
2. `@babel/preset-react` should use the `automatic` runtime.

Relevant plugin-core PR: https://github.com/cortexapps/plugin-core/pull/31