### PR TITLE
fix: fix test setup again

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,0 +1,26 @@
+name: Lint and test
+
+env:
+  GITHUB_PASSWORD: ${{secrets.GITHUB_TOKEN}}
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # the package.json purposely contains some invalid characters for templating
+      # so temporarily set it to something valid to run yarn commands
+      - run: |
+          cd {{cookiecutter.project_name}}
+          npm pkg set 'name'='testing'
+          npm pkg set 'version'='0.0.1'
+          npm pkg set 'license'='MIT'
+          yarn
+          yarn lint
+          yarn test
+          yarn build

--- a/{{cookiecutter.project_name}}/jest.config.js
+++ b/{{cookiecutter.project_name}}/jest.config.js
@@ -5,6 +5,8 @@ module.exports = {
       "<rootDir>/__mocks__/fileMock.js",
     // map style asset imports to a stub file under the assumption they are not important to our tests
     "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
+    "@cortexapps/plugin-core/components": "<rootDir>/node_modules/@cortexapps/plugin-core/dist/components.js",
+    "@cortexapps/plugin-core": "<rootDir>/node_modules/@cortexapps/plugin-core/dist/index.js",
   },
   setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
   testEnvironment: "jsdom",

--- a/{{cookiecutter.project_name}}/jest.config.js
+++ b/{{cookiecutter.project_name}}/jest.config.js
@@ -5,8 +5,10 @@ module.exports = {
       "<rootDir>/__mocks__/fileMock.js",
     // map style asset imports to a stub file under the assumption they are not important to our tests
     "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
-    "@cortexapps/plugin-core/components": "<rootDir>/node_modules/@cortexapps/plugin-core/dist/components.js",
-    "@cortexapps/plugin-core": "<rootDir>/node_modules/@cortexapps/plugin-core/dist/index.js",
+    "@cortexapps/plugin-core/components":
+      "<rootDir>/node_modules/@cortexapps/plugin-core/dist/components.js",
+    "@cortexapps/plugin-core":
+      "<rootDir>/node_modules/@cortexapps/plugin-core/dist/index.js",
   },
   setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
   testEnvironment: "jsdom",

--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -3,7 +3,7 @@
   "version": "{{cookiecutter.version}}",
   "license": "{{cookiecutter.license}}",
   "dependencies": {
-    "@cortexapps/plugin-core": "^1.4.0",
+    "@cortexapps/plugin-core": "^1.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/{{cookiecutter.project_name}}/setupTests.ts
+++ b/{{cookiecutter.project_name}}/setupTests.ts
@@ -1,1 +1,61 @@
 import "@testing-library/jest-dom/extend-expect";
+
+const mockContext = {
+  apiBaseUrl: 'https://api.cortex.dev',
+  entity: {
+    definition: null,
+    description: null,
+    groups: null,
+    name: 'Inventory planner',
+    ownership: {
+      emails: [
+        {
+          description: null,
+          email: 'nikhil@cortex.io',
+          inheritance: null,
+          id: 1,
+        },
+      ],
+    },
+    tag: 'inventory-planner',
+    type: 'service',
+  },
+  location: "ENTITY",
+  user: {
+    email: 'ganesh@cortex.io',
+    name: 'Ganesh Datta',
+    role: "ADMIN",
+  },
+};
+
+jest.mock("@cortexapps/plugin-core/components", () => {
+  const originalModule = jest.requireActual("@cortexapps/plugin-core/components");
+  return {
+    ...originalModule,
+    usePluginContext: () => {
+      return mockContext;
+    },
+    PluginProvider: ({ children }) => {
+      return children;
+    },
+  };
+});
+
+jest.mock("@cortexapps/plugin-core", () => {
+  const originalModule = jest.requireActual("@cortexapps/plugin-core");
+  return {
+    ...originalModule,
+    CortexApi: {
+      ...originalModule.CortexApi,
+      getContext: () => {
+        return mockContext;
+      },
+    },
+    components: {
+      ...originalModule.components,
+      PluginProvider: ({ children }) => {
+        return children;
+      },
+    },
+  };
+});

--- a/{{cookiecutter.project_name}}/setupTests.ts
+++ b/{{cookiecutter.project_name}}/setupTests.ts
@@ -1,35 +1,37 @@
 import "@testing-library/jest-dom/extend-expect";
 
 const mockContext = {
-  apiBaseUrl: 'https://api.cortex.dev',
+  apiBaseUrl: "https://api.cortex.dev",
   entity: {
     definition: null,
     description: null,
     groups: null,
-    name: 'Inventory planner',
+    name: "Inventory planner",
     ownership: {
       emails: [
         {
           description: null,
-          email: 'nikhil@cortex.io',
+          email: "nikhil@cortex.io",
           inheritance: null,
           id: 1,
         },
       ],
     },
-    tag: 'inventory-planner',
-    type: 'service',
+    tag: "inventory-planner",
+    type: "service",
   },
   location: "ENTITY",
   user: {
-    email: 'ganesh@cortex.io',
-    name: 'Ganesh Datta',
+    email: "ganesh@cortex.io",
+    name: "Ganesh Datta",
     role: "ADMIN",
   },
 };
 
 jest.mock("@cortexapps/plugin-core/components", () => {
-  const originalModule = jest.requireActual("@cortexapps/plugin-core/components");
+  const originalModule = jest.requireActual(
+    "@cortexapps/plugin-core/components"
+  );
   return {
     ...originalModule,
     usePluginContext: () => {
@@ -49,12 +51,6 @@ jest.mock("@cortexapps/plugin-core", () => {
       ...originalModule.CortexApi,
       getContext: () => {
         return mockContext;
-      },
-    },
-    components: {
-      ...originalModule.components,
-      PluginProvider: ({ children }) => {
-        return children;
       },
     },
   };


### PR DESCRIPTION
Tests were broke again with the base setup.

1. Jest doesn't like ESM, and apparently `@cortexapps/plugin-core` emits a format that it can't recognize properly. Now we're forcing it to use the CJS output so it doesn't choke on ES6 syntax.
2. Since our base `<App>` now auto-fetches context, we need to mock the fetch since there is no actual iframe parent to communicate with.
3. Adds CI to prevent further regressions (pulled from https://github.com/cortexapps/cookiecutter-cortex-plugin/pull/13)