### PR TITLE
feat: make compatible with plugin-core v2

### DIFF
--- a/{{cookiecutter.project_name}}/jest.config.js
+++ b/{{cookiecutter.project_name}}/jest.config.js
@@ -6,9 +6,9 @@ module.exports = {
     // map style asset imports to a stub file under the assumption they are not important to our tests
     "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
     "@cortexapps/plugin-core/components":
-      "<rootDir>/node_modules/@cortexapps/plugin-core/dist/components.js",
+      "<rootDir>/node_modules/@cortexapps/plugin-core/dist/components.cjs.js",
     "@cortexapps/plugin-core":
-      "<rootDir>/node_modules/@cortexapps/plugin-core/dist/index.js",
+      "<rootDir>/node_modules/@cortexapps/plugin-core/dist/index.cjs.js",
   },
   setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
   testEnvironment: "jsdom",

--- a/{{cookiecutter.project_name}}/webpack.config.js
+++ b/{{cookiecutter.project_name}}/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = (env, argv) => ({
         },
       }),
     ],
+    usedExports: true,
   },
 
   // Webpack tries these extensions for you if you omit the extension, like "import './file'"


### PR DESCRIPTION
* Small changes for compatibility of `@cortexapps/plugin-core@^2.0` (rewrite as ES Module)
* Updates dependency for `@cortexapps/plugin-core@^2.0`

**With this change, the base plugin bundle size should reduce from ~5MB => 170kB**

### TODO
- [ ] Bump the dependency version once 2.0 is published