### PR TITLE
feat: add iframe-resizer from cdn

### DIFF
--- a/{{cookiecutter.project_name}}/src/index.html
+++ b/{{cookiecutter.project_name}}/src/index.html
@@ -1,3 +1,10 @@
 <html>
+  <head>
+    <script
+      defer
+      type="text/javascript"
+      src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.7/iframeResizer.contentWindow.js"
+    ></script>
+  </head>
   <div id="cortex-plugin-root"></div>
 </html>


### PR DESCRIPTION
## Background

Parent pages do a best guess to determine the size of the iframe they render (when not given explicit instructions) and do not respond dynamically to iframe changes. This presents a challenge for plugins that dynamically load content, where a short loading height might permanently constraint the height of the iframe even if lots of data is loaded.

Jira: https://cortex1.atlassian.net/browse/CET-4855

## This PR

* Adds the [iframe-resizer](https://github.com/davidjbradshaw/iframe-resizer) script to communicate with the resizing parent.
  * Corresponding app PR: https://github.com/cortexapps/brain-app/pull/4113