### PR TITLE
feat: bump iframe-resizer

### DIFF
--- a/{{cookiecutter.project_name}}/src/index.html
+++ b/{{cookiecutter.project_name}}/src/index.html
@@ -3,7 +3,7 @@
     <script
       defer
       type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.7/iframeResizer.contentWindow.js"
+      src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child"
     ></script>
   </head>
   <div id="cortex-plugin-root"></div>


### PR DESCRIPTION
We use `react-iframe-resizer` for plugin resizing. It's a bit faulty in some scenarios, but it's improving. We're on v4, and v5 has a bunch of functional + performance improvements (and package renames).

**Note**: this upgrade is dependent on the app upgrading to v5 first